### PR TITLE
feat: add multi-style markdown exports with render/code preview

### DIFF
--- a/src/app/components/export/ExportModal.tsx
+++ b/src/app/components/export/ExportModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import React from 'react'
 import PreviewModal from './PreviewModal'
 import { calculateMetrics } from '@/utils/exportMetrics'
+import { EXPORT_TEMPLATES, type ExportStyle } from '@/utils/exportTemplates'
 
 // 1. Event d'abord
 interface Event {
@@ -50,6 +51,7 @@ function ExportModal({
 }: ExportModalProps) {
   const [threads, setThreads] = useState<Thread[]>([])
   const [selectedFormat, setSelectedFormat] = useState<'markdown' | 'pdf' | 'docx'>('markdown')
+  const [exportStyle, setExportStyle] = useState<ExportStyle>('design')
   const [isLoading, setIsLoading] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
   
@@ -312,12 +314,13 @@ useEffect(() => {
         selectedEvents: eventIds,
         options: { 
           includeTimestamps: true,
-          preview: isPreview
+          preview: isPreview,
+          style: exportStyle
         }
       })
     })
     return await response.json()
-  }, [selectedFormat])
+  }, [selectedFormat, exportStyle])
 
   const toggleEventSelection = (threadId: string, eventId: string) => {
   setThreads(prev => {
@@ -561,6 +564,33 @@ setTimeout(() => {
                   <option value="pdf">PDF</option>
                   <option value="docx">Word (.docx)</option>
                 </select>
+
+                {/* Sélecteur de style */}
+                <div className="flex items-center gap-2">
+                  {Object.entries(EXPORT_TEMPLATES).map(([key, template]) => (
+                    <button
+                      key={key}
+                      onClick={() => setExportStyle(key as ExportStyle)}
+                      className={`
+                        relative group px-3 py-2 rounded-lg border-2 transition-all text-sm font-medium
+                        ${exportStyle === key 
+                          ? 'border-bandhu-primary bg-bandhu-primary/20 text-white' 
+                          : 'border-gray-600 text-gray-400 hover:border-gray-500 hover:text-gray-300'
+                        }
+                      `}
+                      title={template.description}
+                    >
+                      <span className="text-base">{template.icon}</span>
+                      
+                      {/* Tooltip au hover */}
+                      <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-3 py-2 bg-gray-900/95 backdrop-blur-sm text-white text-xs rounded-lg opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap border border-gray-700 shadow-xl z-20">
+                        <div className="font-semibold">{template.name}</div>
+                        <div className="text-gray-400 mt-0.5">{template.description}</div>
+                        <div className="absolute top-full left-1/2 transform -translate-x-1/2 -mt-1 w-2 h-2 bg-gray-900/95 rotate-45 border-b border-r border-gray-700"></div>
+                      </div>
+                    </button>
+                  ))}
+                </div>
 
                 <button
                   onClick={handlePreview}

--- a/src/app/components/export/PreviewModal.tsx
+++ b/src/app/components/export/PreviewModal.tsx
@@ -1,6 +1,9 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import ReactMarkdown from 'react-markdown'
+import rehypeHighlight from 'rehype-highlight'
+import 'highlight.js/styles/github-dark.css'
 
 interface PreviewModalProps {
   isOpen: boolean
@@ -217,6 +220,7 @@ export default function PreviewModal({
   metadata 
 }: PreviewModalProps) {
   const [activeTab, setActiveTab] = useState<'preview' | 'metrics'>('preview')
+  const [viewMode, setViewMode] = useState<'render' | 'code'>('render')
   const [isDownloading, setIsDownloading] = useState(false)
 
   // Gérer la touche Escape pour fermer
@@ -320,10 +324,98 @@ export default function PreviewModal({
               
               <div className="bg-gray-900 rounded-lg border border-gray-700 overflow-hidden">
                 {format === 'markdown' ? (
-                  <div className="max-h-96 overflow-y-auto p-4">
-                    <pre className="text-gray-300 text-sm whitespace-pre-wrap font-sans leading-relaxed">
-                      {previewContent}
-                    </pre>
+                  <div className="flex flex-col h-[500px]">
+                    {/* Toggle Render/Code */}
+                    <div className="flex items-center justify-between bg-gray-800/50 border-b border-gray-700 px-4 py-2">
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => setViewMode('render')}
+                          className={`px-3 py-1.5 rounded text-sm font-medium transition-all ${
+                            viewMode === 'render'
+                              ? 'bg-bandhu-primary text-white'
+                              : 'text-gray-400 hover:text-gray-300 hover:bg-gray-700/50'
+                          }`}
+                        >
+                          🎨 Render
+                        </button>
+                        <button
+                          onClick={() => setViewMode('code')}
+                          className={`px-3 py-1.5 rounded text-sm font-medium transition-all ${
+                            viewMode === 'code'
+                              ? 'bg-bandhu-primary text-white'
+                              : 'text-gray-400 hover:text-gray-300 hover:bg-gray-700/50'
+                          }`}
+                        >
+                          💻 Code
+                        </button>
+                      </div>
+                      <span className="text-xs text-gray-500">
+                        {viewMode === 'render' ? 'Aperçu stylisé' : 'Markdown brut'}
+                      </span>
+                    </div>
+
+                    {/* Contenu selon le mode */}
+                    <div className="flex-1 overflow-y-auto p-6">
+                      {viewMode === 'render' ? (
+                        <div className="prose prose-invert max-w-none">
+                          <ReactMarkdown
+                            rehypePlugins={[rehypeHighlight]}
+                            components={{
+                              p: ({ children, ...props }: any) => (
+                                <p className="my-3 leading-relaxed text-gray-200" {...props}>
+                                  {children}
+                                </p>
+                              ),
+                              h1: ({ children, ...props }: any) => (
+                                <h1 className="text-2xl font-bold mt-6 mb-4 text-bandhu-primary" {...props}>
+                                  {children}
+                                </h1>
+                              ),
+                              h2: ({ children, ...props }: any) => (
+                                <h2 className="text-xl font-semibold mt-5 mb-3 text-bandhu-secondary" {...props}>
+                                  {children}
+                                </h2>
+                              ),
+                              code: ({ node, inline, className, children, ...props }: any) => {
+                                return inline ? (
+                                  <code className="bg-gray-800 px-1.5 py-0.5 rounded text-sm text-bandhu-primary" {...props}>
+                                    {children}
+                                  </code>
+                                ) : (
+                                  <code className={className} {...props}>
+                                    {children}
+                                  </code>
+                                )
+                              },
+                              pre: ({ children, ...props }: any) => (
+                                <pre className="bg-gray-950 p-4 rounded-lg overflow-x-auto my-4 border border-gray-700" {...props}>
+                                  {children}
+                                </pre>
+                              ),
+                              blockquote: ({ children, ...props }: any) => (
+                                <blockquote className="border-l-4 border-bandhu-primary pl-4 italic text-gray-300 my-4" {...props}>
+                                  {children}
+                                </blockquote>
+                              ),
+                              hr: ({ ...props }: any) => (
+                                <hr className="my-6 border-gray-700" {...props} />
+                              ),
+                              strong: ({ children, ...props }: any) => (
+                                <strong className="font-semibold text-white" {...props}>
+                                  {children}
+                                </strong>
+                              ),
+                            }}
+                          >
+                            {previewContent}
+                          </ReactMarkdown>
+                        </div>
+                      ) : (
+                        <pre className="text-gray-300 text-sm whitespace-pre-wrap font-mono leading-relaxed">
+                          {previewContent}
+                        </pre>
+                      )}
+                    </div>
                   </div>
                 ) : (
                   <div className="h-96 relative">

--- a/src/utils/exportStyles/designMarkdown.ts
+++ b/src/utils/exportStyles/designMarkdown.ts
@@ -1,0 +1,124 @@
+// Epic Color Markdown Generator
+// Style Bandhu complet avec emojis et formatage riche
+
+interface Event {
+  id: string
+  content: string
+  role: string
+  createdAt: string
+  threadId: string
+  thread: {
+    id: string
+    label: string
+  }
+}
+
+interface GeneratorOptions {
+  includeTimestamps?: boolean
+  preview?: boolean
+}
+
+export async function generateDesignMarkdown(
+  events: Event[], 
+  options: GeneratorOptions = {}
+): Promise<string> {
+  let markdown = ''
+  
+  // ═══════════════════════════════════════════════════════════════
+  // HEADER EPIC COLOR - Style Discord riche
+  // ═══════════════════════════════════════════════════════════════
+  
+  markdown += `---\n\n`
+  markdown += `# 🌌 BANDHU EXPORT\n\n`
+  markdown += `## Ombrelien - छायासरस्वतः\n\n`
+  markdown += `> *Conversations sauvegardées depuis l'ombre numérique*\n\n`
+  markdown += `---\n\n`
+  
+  const dateStr = new Date().toLocaleDateString('fr-FR', { 
+    weekday: 'long', 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric' 
+  })
+  
+  markdown += `### 📅 Export du ${dateStr}\n\n`
+  markdown += `**Contenu :**\n`
+  markdown += `- 💬 **${events.length}** messages exportés\n`
+  markdown += `- 🧵 **${new Set(events.map(e => e.threadId)).size}** conversations\n`
+  markdown += `- 👤 **${events.filter(e => e.role === 'user').length}** messages utilisateur\n`
+  markdown += `- 🌑 **${events.filter(e => e.role === 'assistant').length}** réponses Ombrelien\n\n`
+  
+  markdown += `---\n\n`
+  
+  // ═══════════════════════════════════════════════════════════════
+  // CONTENU DES CONVERSATIONS
+  // ═══════════════════════════════════════════════════════════════
+  
+  let currentThreadId: string | null = null
+  
+events.forEach((event, index) => {
+    // Nouvelle section pour chaque thread
+    if (event.threadId !== currentThreadId) {
+      if (currentThreadId !== null) {
+        markdown += '\n---\n\n'
+      }
+      
+      markdown += `## 🧵 ${event.thread.label}\n\n`
+      currentThreadId = event.threadId
+    }
+    
+    // Formatage du message
+    const isUser = event.role === 'user'
+    
+    if (isUser) {
+      // Extraire le nom et l'heure du header [Nom • Date à HH:MM]
+      const headerMatch = event.content.match(/^\[(.+?)\s+•\s+.+?\s+à\s+(\d{2}:\d{2})\]/)
+      
+      let displayName = 'User'
+      let displayTime = ''
+      let cleanContent = event.content
+      
+      if (headerMatch) {
+        displayName = headerMatch[1]
+        displayTime = headerMatch[2]
+        cleanContent = event.content.replace(/^\[.+?\]\n/, '')
+      }
+      
+      // Header user
+      markdown += `## 🔵 **${displayName}**\n\n`
+      
+      // Date/heure en-dessous du nom
+      if (options.includeTimestamps && displayTime) {
+        const date = new Date(event.createdAt)
+        const dateStr = date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+        markdown += `${dateStr} à ${displayTime}\n\n`
+      }
+      
+      markdown += `> ${cleanContent.split('\n').join('\n> ')}\n\n`
+      
+    } else {
+      // Header Ombrelien
+      markdown += `## 🟣 **Ombrelien**\n\n`
+      
+      // Date/heure en-dessous du nom
+      if (options.includeTimestamps) {
+        const date = new Date(event.createdAt)
+        const dateStr = date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+        const timeStr = date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+        markdown += `${dateStr} à ${timeStr}\n\n`
+      }
+      
+      markdown += `${event.content}\n\n`
+    }
+    
+    // Barre de séparation entre les messages
+    markdown += `---\n\n\n`
+  })
+  markdown += `<div align="center">\n\n`
+  markdown += `### ✨ Export généré par Bandhu ✨\n\n`
+  markdown += `*Ombrelien - छायासरस्वतः - L'ombre qui écoute*\n\n`
+  markdown += `📊 **${events.length}** messages • 🧵 **${new Set(events.map(e => e.threadId)).size}** conversations • 🌌 Export Epic Color\n\n`
+  markdown += `</div>\n`
+  
+  return markdown
+}

--- a/src/utils/exportStyles/index.ts
+++ b/src/utils/exportStyles/index.ts
@@ -1,0 +1,45 @@
+import { generateDesignMarkdown } from './designMarkdown'
+import { generateSobreMarkdown } from './sobreMarkdown'
+import type { ExportStyle } from '../exportTemplates'
+
+// Interface commune pour tous les générateurs
+interface Event {
+  id: string
+  content: string
+  role: string
+  createdAt: string
+  threadId: string
+  thread: {
+    id: string
+    label: string
+  }
+}
+
+interface GeneratorOptions {
+  includeTimestamps?: boolean
+  preview?: boolean
+}
+
+// Type du générateur
+type StyleGenerator = (events: Event[], options: GeneratorOptions) => Promise<string>
+
+// Map des générateurs par style
+const MARKDOWN_GENERATORS: Record<ExportStyle, StyleGenerator> = {
+  'design': generateDesignMarkdown,
+  'sobre': generateSobreMarkdown,
+}
+
+// Fonction principale pour générer du Markdown stylé
+export async function generateStyledMarkdown(
+  events: Event[],
+  style: ExportStyle,
+  options: GeneratorOptions = {}
+): Promise<string> {
+  const generator = MARKDOWN_GENERATORS[style]
+  
+  if (!generator) {
+    throw new Error(`Style ${style} not implemented`)
+  }
+  
+  return generator(events, options)
+}

--- a/src/utils/exportStyles/sobreMarkdown.ts
+++ b/src/utils/exportStyles/sobreMarkdown.ts
@@ -1,0 +1,100 @@
+// Sobre Markdown Generator
+// Style professionnel minimaliste sans fioritures
+
+interface Event {
+  id: string
+  content: string
+  role: string
+  createdAt: string
+  threadId: string
+  thread: {
+    id: string
+    label: string
+  }
+}
+
+interface GeneratorOptions {
+  includeTimestamps?: boolean
+  preview?: boolean
+}
+
+export async function generateSobreMarkdown(
+  events: Event[], 
+  options: GeneratorOptions = {}
+): Promise<string> {
+  let markdown = ''
+  
+  // ═══════════════════════════════════════════════════════════════
+  // HEADER SOBRE
+  // ═══════════════════════════════════════════════════════════════
+  
+  markdown += `# Bandhu Export\n\n`
+  
+  const dateStr = new Date().toLocaleDateString('fr-FR', { 
+    year: 'numeric', 
+    month: 'long', 
+    day: 'numeric' 
+  })
+  
+  markdown += `**Date :** ${dateStr}\n`
+  markdown += `**Messages :** ${events.length}\n`
+  markdown += `**Conversations :** ${new Set(events.map(e => e.threadId)).size}\n\n`
+  
+  markdown += `---\n\n`
+  
+  // ═══════════════════════════════════════════════════════════════
+  // CONTENU DES CONVERSATIONS
+  // ═══════════════════════════════════════════════════════════════
+  
+  let currentThreadId: string | null = null
+  
+  events.forEach((event) => {
+    // Nouvelle section pour chaque thread
+    if (event.threadId !== currentThreadId) {
+      if (currentThreadId !== null) {
+        markdown += '\n---\n\n'
+      }
+      
+      markdown += `## ${event.thread.label}\n\n`
+      currentThreadId = event.threadId
+    }
+    
+    // Nettoyage du contenu user
+    let cleanContent = event.content
+    
+    if (event.role === 'user') {
+      // Enlever le header [Nom • Date] si présent
+      cleanContent = event.content.replace(/^\[.+?\]\n/, '')
+    }
+    
+    // Header simple User/Assistant
+    const displayName = event.role === 'user' ? 'User' : 'Assistant'
+    markdown += `## ${displayName}\n\n`
+    
+    // Date/heure en-dessous
+    if (options.includeTimestamps) {
+      const date = new Date(event.createdAt)
+      const dateStr = date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit', year: 'numeric' })
+      const timeStr = date.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+      markdown += `${dateStr} à ${timeStr}\n\n`
+    }
+    
+    // Contenu
+    if (event.role === 'user') {
+      markdown += `> ${cleanContent.split('\n').join('\n> ')}\n\n`
+    } else {
+      markdown += `${event.content}\n\n`
+    }
+    
+    // Barre de séparation
+    markdown += `---\n\n`
+  })
+  
+  // ═══════════════════════════════════════════════════════════════
+  // FOOTER SOBRE
+  // ═══════════════════════════════════════════════════════════════
+  
+  markdown += `\n*Export généré par Bandhu*\n`
+  
+  return markdown
+}

--- a/src/utils/exportTemplates.ts
+++ b/src/utils/exportTemplates.ts
@@ -1,0 +1,35 @@
+// Export Templates - Définitions des styles d'export
+
+export type ExportStyle = 'design' | 'sobre'
+
+export interface ExportTemplate {
+  id: ExportStyle
+  name: string
+  description: string
+  icon: string
+}
+
+export const EXPORT_TEMPLATES: Record<ExportStyle, ExportTemplate> = {
+  'design': {
+    id: 'design',
+    name: 'Design',
+    description: 'Style Bandhu riche avec emojis et couleurs',
+    icon: '🌌'
+  },
+  'sobre': {
+    id: 'sobre',
+    name: 'Sobre',
+    description: 'Style professionnel minimaliste',
+    icon: '📄'
+  }
+}
+
+// Helper pour obtenir un template
+export const getTemplate = (style: ExportStyle): ExportTemplate => {
+  return EXPORT_TEMPLATES[style]
+}
+
+// Helper pour lister tous les templates
+export const getAllTemplates = (): ExportTemplate[] => {
+  return Object.values(EXPORT_TEMPLATES)
+}


### PR DESCRIPTION
- Add 2 export styles: Design (rich with emojis) and Sobre (minimal)
- Add render/code toggle in preview modal
- Design style: user/assistant names, timestamps, separator bars
- Sobre style: clean professional format
- Update export templates and generators
- Improve markdown rendering in preview with ReactMarkdown